### PR TITLE
Add detailed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See [/CONTRIBUTING.md](/CONTRIBUTING.md).
 
 Documentation on how to develop Altinn apps can be found [here](https://docs.altinn.studio/).
 
+Project documentation is available in the [docs](docs/index.md) folder.
 ## Architecture
 
 This template is built using .NET

--- a/docs/analyzers/index.md
+++ b/docs/analyzers/index.md
@@ -1,0 +1,5 @@
+# Analyzere
+
+Prosjektet inneholder Roslyn-analyzere som hjelper apputviklere å unngå vanlige feil. Eksempelvis rapporterer `HttpContextAccessorUsageAnalyzer` dersom `IHttpContextAccessor` brukes direkte i appkoden.
+
+Analyserene pakkes som `Altinn.App.Analyzers` og kan refereres fra appens prosjektfil for å få statiske kodevarsler under bygging.

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,0 +1,13 @@
+# Autentisering
+
+`AuthenticationController` håndterer tokenfornying og sletting av runtime-cookie.
+
+Kall mot endepunktet returnerer HTTP 200 dersom token ble fornyet, ellers HTTP 400 hvis det feiler.
+
+```csharp
+[Authorize]
+[HttpGet("{org}/{app}/api/[controller]/keepAlive")]
+public async Task<IActionResult> KeepAlive()
+```
+
+`InvalidateCookie` fjerner `AltinnStudioRuntime`-cookien.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,20 @@
+# API-biblioteket
+
+`Altinn.App.Api` tilbyr kontroller og endepunkter som eksponerer funksjonalitet i en Altinn-app.
+
+Eksempelvis har `AuthenticationController` metoder for å forlenge token og invalidere cookie.
+
+Tilgjengelige kontroller inkluderer blant annet:
+- `AccountController` for innlogging
+- `ApplicationMetadataController` som eksponerer app-informasjon
+- `ActionsController` for brukerhandlinger
+- `AuthenticationController` for tokenbehandling
+
+
+```csharp
+[Authorize]
+[HttpGet("{org}/{app}/api/[controller]/keepAlive")]
+public async Task<IActionResult> KeepAlive()
+```
+
+Se også [Autentisering](authentication.md) for en nærmere beskrivelse.

--- a/docs/core/authentication.md
+++ b/docs/core/authentication.md
@@ -1,0 +1,27 @@
+# Autentiseringsmodell
+
+`Altinn.App.Core` benytter klassen `AuthenticationContext` for å lese innloggingsinformasjon fra `HttpContext`.
+Metoden `Parse` analyserer JWT tokenet og returnerer en av typene som arver fra `Authenticated`:
+
+- `Authenticated.User` for innloggede brukere
+- `Authenticated.SystemUser` for systemtokener
+- `Authenticated.Org` for organisasjoner
+- `Authenticated.None` dersom forespørselen ikke er autentisert
+
+Eksempel på bruk i en controller:
+
+```csharp
+public class ExampleController(AuthenticationContext authCtx)
+{
+    [HttpGet]
+    public IActionResult CurrentUser()
+    {
+        var auth = authCtx.Authentication;
+        if (auth is Authenticated.User user)
+        {
+            return Ok($"Logged in as {user.UserId}");
+        }
+        return Unauthorized();
+    }
+}
+```

--- a/docs/core/configuration.md
+++ b/docs/core/configuration.md
@@ -1,0 +1,33 @@
+# Konfigurasjon
+
+`GeneralSettings` klassen samler sentrale konfigurasjonsverdier for apper. Flere av egenskapene er forklart i kildekoden med XML-kommentarer.
+
+```csharp
+public class GeneralSettings
+{
+    /// <summary>
+    /// Prefiks som benyttes i mykere valideringsmeldinger.
+    /// </summary>
+    public string SoftValidationPrefix { get; set; } = "*WARNING*";
+
+    /// <summary>
+    /// Navnet på cookien som lagrer valgt party.
+    /// </summary>
+    public string AltinnPartyCookieName { get; set; } = "AltinnPartyId";
+    /// <summary>
+    /// Adressen applikasjonen tilgjengeliggjøres på.
+    /// </summary>
+    public string HostName { get; set; } = "local.altinn.cloud";
+
+    /// <summary>
+    /// Base-URL som bygges opp med øvrige innstillinger.
+    /// </summary>
+    public string ExternalAppBaseUrl { get; set; } = "http://{hostName}/{org}/{app}/";
+}
+```
+`GeneralSettingsExtensions.FormattedExternalAppBaseUrlWithTrailingPound` kan
+brukes for å generere URL med trailing `/#` slik frontend forventer.
+
+`GeneralSettings` kan injiseres via `IOptions<GeneralSettings>` og benyttes i kontroller eller tjenester.
+
+Miljøinformasjon håndteres av `AltinnEnvironments`, som kartlegger ulike miljønavn til et `HostingEnvironment`-oppsett.

--- a/docs/core/externalapi.md
+++ b/docs/core/externalapi.md
@@ -1,0 +1,19 @@
+# Eksterne API-er
+
+`IExternalApiService` gir tilgang til data fra definerte eksterne API-er. Hver integrasjon implementerer `IExternalApiClient` som registreres via `IExternalApiFactory`.
+
+For å hente data benyttes `GetExternalApiData`:
+
+```csharp
+var result = await externalApiService.GetExternalApiData(
+    externalApiId: "myApi",
+    instanceIdentifier: instanceId,
+    queryParams: new Dictionary<string, string>()
+);
+if (result.WasExternalApiFound)
+{
+    // result.Data inneholder svaret fra API-et
+}
+```
+
+Integrasjonene konfigureres i appens `applicationmetadata.json` hvor det defineres hvilke API-id-er som er tilgjengelige.

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -1,0 +1,15 @@
+# Kjernebiblioteket
+
+`Altinn.App.Core` inneholder funksjonalitet som styrer kjernen i en Altinn-app.
+
+Biblioteket tilbyr blant annet:
+
+- Grensesnitt og klienter for lagring og prosess
+- Konfigurasjon via `GeneralSettings`
+- Tilpassede brukerhandlinger via `IUserAction`
+- Autentiseringslogikk gjennom `Authenticated` og `AuthenticationContext`
+- Integrasjon mot eFormidling for dokumentutsendelse
+- Integrasjoner mot eksterne API via `IExternalApiService`
+- Utvidelsesmetoder og hjelpere
+
+Se [konfigurasjon](configuration.md) for mer informasjon om hvordan biblioteket settes opp.

--- a/docs/features/useractions.md
+++ b/docs/features/useractions.md
@@ -1,0 +1,22 @@
+# Brukerhandlinger
+
+Biblioteket støtter tilpassede brukerhandlinger via grensesnittet `IUserAction`. Dette markeres med attributtet `ImplementableByApps` slik at handlingene kan implementeres i appen.
+
+```csharp
+public interface IUserAction
+{
+    /// <summary>
+    /// Id til handlingen
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Metode som utfører selve handlingen
+    /// </summary>
+    Task<UserActionResult> HandleAction(UserActionContext context);
+}
+```
+
+`UserActionService` hjelper med å hente riktig implementasjon basert på `Id`.
+Innebygde handlinger som "sign" og "pay" kan brukes direkte i prosessdefinisjonen.
+Egne handlinger implementeres i app-koden og registreres via avhengighetsinjeksjon.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# Altinn.App biblioteker
+
+Dette prosjektet inneholder .NET-biblioteker som brukes av apper i Altinn 3. Dokumentasjonen her bygger på inline-dokumentasjonen i kildekoden og gir en oversikt over hvordan sentrale klasser, grensesnitt og metoder kan benyttes.
+
+## Innhold
+
+- [Kjernebiblioteket](core/index.md)
+- [API-biblioteket](api/index.md)
+- [Funksjoner](features/useractions.md)
+- [Analyzere](analyzers/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: Altinn.App Dokumentasjon
+docs_dir: docs
+nav:
+  - Hjem: index.md
+  - Kjernebiblioteket:
+    - Oversikt: core/index.md
+    - Konfigurasjon: core/configuration.md
+    - Autentisering: core/authentication.md
+    - Eksterne API: core/externalapi.md
+  - API-biblioteket:
+    - Oversikt: api/index.md
+    - Autentisering: api/authentication.md
+  - Funksjoner:
+    - Brukerhandlinger: features/useractions.md
+  - Analyzere:
+    - Oversikt: analyzers/index.md
+


### PR DESCRIPTION
## Summary
- expand README with docs reference
- flesh out documentation site with pages on authentication, external APIs and analyzers
- document controllers and built-in features
- list more settings in configuration docs
- update MkDocs navigation

## Testing
- `dotnet test solutions/All.sln -v minimal --no-restore --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0949ffac8327bbe1eace9dfd60d7