### PR TITLE
Add architecture docs and expand interfaces

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,3 +8,5 @@ Dette prosjektet inneholder .NET-biblioteker som brukes av apper i Altinn 3. Dok
 - [API-biblioteket](api/index.md)
 - [Funksjoner](features/useractions.md)
 - [Analyzere](analyzers/index.md)
+- [Grensesnittoversikt](interfaces.md)
+- [Arkitekturoversikt](overview.md)

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,131 @@
+# Interface overview
+
+The list below is automatically generated from the inline XML comments in the source. Each entry shows the interface name, file path and first summary sentence.
+
+- **IAbandonTaskEventHandler** (src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IAbandonTaskEventHandler.cs) - Interface for abandon task event handlers, which are executed when a process abandon task event is triggered.
+- **IAltinnPartyClient** (src/Altinn.App.Core/Internal/Registers/IAltinnPartyClient.cs) - Interface for register functionality
+- **IAppEvents** (src/Altinn.App.Core/Interface/IAppEvents.cs) - Interface for implementing a receiver handling instance events.
+- **IAppEvents** (src/Altinn.App.Core/Internal/App/IAppEvents.cs) - Interface for implementing a receiver handling instance events.
+- **IAppMetadata** (src/Altinn.App.Core/Internal/App/IAppMetadata.cs) - Interface for fetching app metadata
+- **IAppModel** (src/Altinn.App.Core/Internal/AppModel/IAppModel.cs) - This interface is used to define the methods that are used to instantiate the applications data model.
+- **IAppOptionsFileHandler** (src/Altinn.App.Core/Features/Options/IAppOptionsFileHandler.cs) - Interface for handling option files on disk
+- **IAppOptionsProvider** (src/Altinn.App.Core/Features/IAppOptionsProvider.cs) - Interface for providing <see cref="AppOptions"/>
+- **IAppOptionsService** (src/Altinn.App.Core/Features/Options/IAppOptionsService.cs) - Interface for working with <see cref="AppOption"/>
+- **IAppResources** (src/Altinn.App.Core/Interface/IAppResources.cs) - Interface for execution functionality
+- **IAppResources** (src/Altinn.App.Core/Internal/App/IAppResources.cs) - Interface for execution functionality
+- **IApplication** (src/Altinn.App.Core/Interface/IApplication.cs) - Interface for retrieving application metadata data related operations
+- **IApplicationClient** (src/Altinn.App.Core/Internal/App/IApplicationClient.cs) - Interface for retrieving application metadata data related operations
+- **IApplicationLanguage** (src/Altinn.App.Core/Internal/Language/IApplicationLanguage.cs) - Interface for retrieving languages supported by the application.
+- **IAuthentication** (src/Altinn.App.Core/Interface/IAuthentication.cs) - Authentication interface.
+- **IAuthenticationClient** (src/Altinn.App.Core/Internal/Auth/IAuthenticationClient.cs) - Authentication interface.
+- **IAuthenticationContext** (src/Altinn.App.Core/Features/Auth/IAuthenticationContext.cs) - Provides access to the current authentication context.
+- **IAuthorization** (src/Altinn.App.Core/Interface/IAuthorization.cs) - Interface for authorization functionality.
+- **IAuthorizationClient** (src/Altinn.App.Core/Internal/Auth/IAuthorizationClient.cs) - Interface for authorization functionality.
+- **IAuthorizationService** (src/Altinn.App.Core/Internal/Auth/IAuthorizationService.cs) - Interface for authorization functionality.
+- **ICorrespondenceAttachmentBuilderFilename** (src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceAttachmentBuilder.cs) - Indicates that the <see cref="CorrespondenceAttachmentBuilder"/> instance is on the <see cref="CorrespondenceAttachment.Filename"/> step.
+- **ICorrespondenceClient** (src/Altinn.App.Core/Features/Correspondence/ICorrespondenceClient.cs) - <p>Contains logic for interacting with the correspondence message service.</p>
+- **ICorrespondenceContentBuilderLanguage** (src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceContentBuilder.cs) - Indicates that the <see cref="CorrespondenceContentBuilder"/> instance is on the <see cref="CorrespondenceContent.Language"/> step.
+- **ICorrespondenceNotificationBuilderTemplate** (src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationBuilder.cs) - Indicates that the <see cref="CorrespondenceNotificationBuilder"/> instance is on the <see cref="CorrespondenceNotification.NotificationTemplate"/> step.
+- **ICorrespondenceNotificationOverrideBuilder** (src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceNotificationOverrideBuilder.cs) - Builder for creating <see cref="CorrespondenceNotification"/> objects with recipient overrides.
+- **ICorrespondenceRequestBuilderResourceId** (src/Altinn.App.Core/Features/Correspondence/Builder/ICorrespondenceRequestBuilder.cs) - Indicates that the <see cref="CorrespondenceRequestBuilder"/> instance is on the <see cref="CorrespondenceRequest.ResourceId"/> step.
+- **IDSF** (src/Altinn.App.Core/Interface/IDSF.cs) - Interface for the resident registration database (DSF: Det sentrale folkeregisteret)
+- **IData** (src/Altinn.App.Core/Interface/IData.cs) - Interface for data handling
+- **IDataClient** (src/Altinn.App.Core/Internal/Data/IDataClient.cs) - Interface for data handling
+- **IDataElementValidator** (src/Altinn.App.Core/Features/IDataElementValidator.cs) - Validator for data elements.
+- **IDataListProvider** (src/Altinn.App.Core/Features/IDataListProvider.cs) - Interface for providing <see cref="DataList"/>
+- **IDataListsService** (src/Altinn.App.Core/Features/DataLists/IDataListsService.cs) - Interface for working with <see cref="DataList"/>
+- **IDataProcessor** (src/Altinn.App.Core/Features/IDataProcessor.cs) - This interface defines all the methods that are required for overriding DataProcessing calls.
+- **IDataService** (src/Altinn.App.Core/Internal/Data/IDataService.cs) - DRAFT. Don't make public yet.
+- **IDataWriteProcessor** (src/Altinn.App.Core/Features/IDataWriteProcessor.cs) - This interface defines how you can make changes to the data model on every write operation from frontend.
+- **IEFormidlingMetadata** (src/Altinn.App.Core/EFormidling/Interface/IEFormidlingMetadata.cs) - Interface for implementing app specific eFormidling metadata to be sendt.
+- **IEFormidlingReceivers** (src/Altinn.App.Core/EFormidling/Interface/IEFormidlingReceivers.cs) - Interface for implementing custom logic for retreiving the receivers of eFormidling shipments.
+- **IEFormidlingService** (src/Altinn.App.Core/EFormidling/Interface/IEFormidlingService.cs) - Interface for implementing custom logic for sending eFormidling shipments. Default implementation is <see cref="Altinn.App.Core.EFormidling.Implementation.DefaultEFormidlingService"/>.
+- **IER** (src/Altinn.App.Core/Interface/IER.cs) - Interface for the entity registry (ER: Enhetsregisteret)
+- **IEmailNotificationClient** (src/Altinn.App.Core/Features/IEmailNotificationClient.cs) - Client for managing Altinn email notifications
+- **IEndEventEventHandler** (src/Altinn.App.Core/Internal/Process/EventHandlers/Interfaces/IEndEventEventHandler.cs) - Interface for end event handlers, which are executed when a process end event is triggered.
+- **IEndTaskEventHandler** (src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IEndTaskEventHandler.cs) - Interface for end task event handlers, which are executed when a process end task event is triggered.
+- **IEventHandler** (src/Altinn.App.Core/Features/IEventHandler.cs) - Class handling a dedicated type of event from the Event system ie. an external event.
+- **IEventHandlerResolver** (src/Altinn.App.Core/Internal/Events/IEventHandlerResolver.cs) - Interface used to resolve the <see cref="IEventHandler"/> implementation that should be used for a given event.
+- **IEventSecretCodeProvider** (src/Altinn.App.Core/Internal/Events/IEventSecretCodeProvider.cs) - Interface for providing a secret code to be used when
+- **IEvents** (src/Altinn.App.Core/Interface/IEvents.cs) - Interface describing client implementations for the Events component in the Altinn 3 platform.
+- **IEventsClient** (src/Altinn.App.Core/Internal/Events/IEventsClient.cs) - Interface describing client implementations for the Events component in the Altinn 3 platform.
+- **IEventsSubscription** (src/Altinn.App.Core/Internal/Events/IEventsSubscription.cs) - Interface describing client implementations for the Events component in the Altinn 3 platform.
+- **IExternalApiClient** (src/Altinn.App.Core/Features/ExternalApi/IExternalApiClient.cs) - Interface for providing external api data
+- **IExternalApiService** (src/Altinn.App.Core/Features/ExternalApi/ExternalApiService.cs) - Result of external api data retrieval
+- **IFileAnalyser** (src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalyser.cs) - Interface for doing extended binary file analysing.
+- **IFileAnalyserFactory** (src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalyserFactory.cs) - Interface responsible for resolving the correct file analysers to run on against a <see cref="DataType"/>.
+- **IFileAnalysisService** (src/Altinn.App.Core/Features/FileAnalyzis/IFileAnalysisService.cs) - Interface for running all file analysers registered on a data type.
+- **IFileValidationService** (src/Altinn.App.Core/Internal/Validation/IFileValidationService.cs) - Interface for running all file validators registered on a data type.
+- **IFileValidator** (src/Altinn.App.Core/Features/Validation/IFileValidator.cs) - Interface for handling validation of files added to an instance.
+- **IFileValidatorFactory** (src/Altinn.App.Core/Internal/Validation/IFileValidatorFactory.cs) - Interface responsible for resolving the correct file validators to run on against a <see cref="DataType"/>.
+- **IFormDataValidator** (src/Altinn.App.Core/Features/IFormDataValidator.cs) - Interface for handling validation of form data.
+- **IFrontendFeatures** (src/Altinn.App.Core/Internal/App/IFrontendFeatures.cs) - Interface reporting features needed by frontend and their status to support multiple versions of the backend
+- **IInstance** (src/Altinn.App.Core/Interface/IInstance.cs) - Interface for handling form data related operations
+- **IInstanceAppOptionsProvider** (src/Altinn.App.Core/Features/IInstanceAppOptionsProvider.cs) - Interface for providing <see cref="AppOptions"/> related to an instance/instance owner.
+- **IInstanceClient** (src/Altinn.App.Core/Internal/Instances/IInstanceClient.cs) - Interface for handling form data related operations
+- **IInstanceDataAccessor** (src/Altinn.App.Core/Features/IInstanceDataAccessor.cs) - Service for accessing data from other data elements in the
+- **IInstanceDataListProvider** (src/Altinn.App.Core/Features/IInstanceDataListProvider.cs) - Interface for providing <see cref="DataList"/> related to an instance/instance owner.
+- **IInstanceDataMutator** (src/Altinn.App.Core/Features/IInstanceDataMutator.cs) - Extension of the IInstanceDataAccessor that allows for adding and removing data elements,
+- **IInstanceEvent** (src/Altinn.App.Core/Interface/IInstanceEvent.cs) - Interface for handling instance event related operations
+- **IInstanceEventClient** (src/Altinn.App.Core/Internal/Instances/IInstanceEventClient.cs) - Interface for handling instance event related operations
+- **IInstanceValidator** (src/Altinn.App.Core/Features/IInstanceValidator.cs) - IInstanceValidator defines the methods that are used to validate data and tasks
+- **IInstantiationProcessor** (src/Altinn.App.Core/Features/IInstantiationProcessor.cs) - IInstantiation defines the methods that must be implemented by a class that handles custom logic during instantiation of a new instance.
+- **IInstantiationValidator** (src/Altinn.App.Core/Features/IInstantiationValidator.cs) - IInstantiationValidator defines the methods that must be implemented by a class that handles custom validation logic during instantiation of a new instance.
+- **ILanguageCodeStandard** (src/Altinn.App.Core/Models/LanguageCode.cs) - Specification details for language code ISO 639-1.
+- **ILayoutEvaluatorStateInitializer** (src/Altinn.App.Core/Internal/Expressions/ILayoutEvaluatorStateInitializer.cs) - Interface for initializing a <see cref="LayoutEvaluatorState" /> from dependency injection services
+- **IMaskinportenClient** (src/Altinn.App.Core/Features/Maskinporten/IMaskinportenClient.cs) - Contains logic for handling authorisation requests with Maskinporten.
+- **IMaskinportenTokenProvider** (src/Altinn.App.Core/Internal/Maskinporten/IMaskinportenTokenProvider.cs) - Defines the interface required for an implementation of a Maskinporte token provider.
+- **IOrderDetailsCalculator** (src/Altinn.App.Core/Features/Payment/IOrderDetailsCalculator.cs) - Interface that app developers need to implement in order to use the payment feature
+- **IOrganizationClient** (src/Altinn.App.Core/Internal/Registers/IOrganizationClient.cs) - Interface for the entity registry (ER: Enhetsregisteret)
+- **IPageOrder** (src/Altinn.App.Core/Features/IPageOrder.cs) - Interface for page order handling in stateful apps
+- **IPaymentProcessor** (src/Altinn.App.Core/Features/Payment/Processors/IPaymentProcessor.cs) - Represents a payment processor that handles payment-related operations.
+- **IPdfFormatter** (src/Altinn.App.Core/Features/IPdfFormatter.cs) - Interface to customize PDF formatting.
+- **IPdfGeneratorClient** (src/Altinn.App.Core/Internal/Pdf/IPdfGeneratorClient.cs) - Defines the required operations on a client of the PDF generator service.
+- **IPdfService** (src/Altinn.App.Core/Internal/Pdf/IPdfService.cs) - Interface for handling generation and storing of PDF's
+- **IPersonClient** (src/Altinn.App.Core/Internal/Registers/IPersonClient.cs) - Describes the required methods for an implementation of a person repository client.
+- **IPersonLookup** (src/Altinn.App.Core/Interface/IPersonLookup.cs) - Describes the methods required by a person lookup service.
+- **IPersonRetriever** (src/Altinn.App.Core/Interface/IPersonRetriever.cs) - Describes the required methods for an implementation of a person repository client.
+- **IPrefill** (src/Altinn.App.Core/Interface/IPrefill.cs) - The prefill service
+- **IPrefill** (src/Altinn.App.Core/Internal/Prefill/IPrefill.cs) - The prefill service
+- **IProcess** (src/Altinn.App.Core/Interface/IProcess.cs) - Process service that encapsulate reading of the BPMN process definition.
+- **IProcessClient** (src/Altinn.App.Core/Internal/Process/Interfaces/IProcessClient.cs) - Process service that encapsulate reading of the BPMN process definition.
+- **IProcessEnd** (src/Altinn.App.Core/Features/IProcessEnd.cs) - Custom logic to run when the entire process has ended. E.g. when we have arrived at an `endEvent` in the BPMN model
+- **IProcessEngine** (src/Altinn.App.Core/Internal/Process/Interfaces/IProcessEngine.cs) - Process engine interface that defines the Altinn App process engine
+- **IProcessEngineAuthorizer** (src/Altinn.App.Core/Internal/Process/Interfaces/IProcessEngineAuthorizer.cs) - Authorizer for the process engine.
+- **IProcessEventDispatcher** (src/Altinn.App.Core/Internal/Process/Interfaces/IProcessEventDispatcher.cs) - Interface for dispatching events that occur during a process
+- **IProcessEventHandlerDelegator** (src/Altinn.App.Core/Internal/Process/Interfaces/IProcessEventHandlerDelegator.cs) - This interface is responsible for delegating process events to the correct event handler.
+- **IProcessExclusiveGateway** (src/Altinn.App.Core/Features/IProcessExclusiveGateway.cs) - Interface for defining custom decision logic for exclusive gateways
+- **IProcessNavigator** (src/Altinn.App.Core/Internal/Process/Interfaces/IProcessNavigator.cs) - Interface used to descipt the process navigator
+- **IProcessReader** (src/Altinn.App.Core/Internal/Process/Interfaces/IProcessReader.cs) - Interface for classes that reads the applications process
+- **IProcessTask** (src/Altinn.App.Core/Internal/Process/ProcessTasks/Interfaces/IProcessTask.cs) - Implement this interface to create a new type of task for the process engine.
+- **IProcessTaskAbandon** (src/Altinn.App.Core/Features/IProcessTaskAbandon.cs) - IProcessTaskAbandon defines a implementation for running logic when a task is abandoned in the apps process
+- **IProcessTaskCleaner** (src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/Interfaces/IProcessTaskCleaner.cs) - Contains common logic to clean up process data
+- **IProcessTaskDataLocker** (src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/Interfaces/IProcessTaskDataLocker.cs) - Can be used to lock data elements connected to a process task
+- **IProcessTaskEnd** (src/Altinn.App.Core/Features/IProcessTaskEnd.cs) - IProcessTaskEnd defines a implementation for running logic when a task ends in the apps process
+- **IProcessTaskFinalizer** (src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/Interfaces/IProcessTaskFinalizer.cs) - Contains common logic for ending a process task.
+- **IProcessTaskInitializer** (src/Altinn.App.Core/Internal/Process/ProcessTasks/Common/Interfaces/IProcessTaskInitializer.cs) - Contains common logic for initializing a process task.
+- **IProcessTaskStart** (src/Altinn.App.Core/Features/IProcessTaskStart.cs) - IProcessTaskStart defines a implementation for running logic when a task starts in the apps process
+- **IProfile** (src/Altinn.App.Core/Interface/IProfile.cs) - Interface for profile functionality
+- **IProfileClient** (src/Altinn.App.Core/Internal/Profile/IProfileClient.cs) - Interface for profile functionality
+- **IRegister** (src/Altinn.App.Core/Interface/IRegister.cs) - Interface for register functionality
+- **ISecrets** (src/Altinn.App.Core/Interface/ISecrets.cs) - Interface for secrets service
+- **ISecretsClient** (src/Altinn.App.Core/Internal/Secrets/ISecretsClient.cs) - Interface for secrets service
+- **IServiceTask** (src/Altinn.App.Core/Internal/Process/ServiceTasks/Interfaces/IServiceTask.cs) - Interface for service tasks that can be executed during a process.
+- **ISignClient** (src/Altinn.App.Core/Internal/Sign/ISignClient.cs) - Interface for httpClient to send sign requests to platform
+- **ISigneeProvider** (src/Altinn.App.Core/Features/Signing/ISigneeProvider.cs) - Interface for implementing app-specific logic for deriving signees.
+- **ISmsNotificationClient** (src/Altinn.App.Core/Features/ISmsNotificationClient.cs) - Client for managing Altinn SMS notifications
+- **IStartTaskEventHandler** (src/Altinn.App.Core/Internal/Process/EventHandlers/ProcessTask/Interfaces/IStartTaskEventHandler.cs) - Interface for start task event handlers, which are executed when a process start task event is triggered.
+- **ITaskEvents** (src/Altinn.App.Core/Interface/ITaskEvents.cs) - Interface for implementing a receiver handling task process events.
+- **ITaskValidator** (src/Altinn.App.Core/Features/ITaskValidator.cs) - Interface for handling validation of tasks.
+- **IText** (src/Altinn.App.Core/Internal/Texts/IText.cs) - Describes the public methods of a text resources service
+- **ITranslationService** (src/Altinn.App.Core/Internal/Texts/ITranslationService.cs) - Describes the public methods of a translation service
+- **IUserAction** (src/Altinn.App.Core/Features/IUserAction.cs) - Interface for implementing custom code for user actions
+- **IUserActionAuthorizer** (src/Altinn.App.Core/Features/IUserActionAuthorizer.cs) - Interface for writing custom authorization logic for actions in the app that cannot be handled by the default authorization policies
+- **IUserActionAuthorizerProvider** (src/Altinn.App.Core/Internal/Process/Authorization/IUserActionAuthorizerProvider.cs) - Register a user action authorizer for a given action and/or task
+- **IUserTokenProvider** (src/Altinn.App.Core/Interface/IUserTokenProvider.cs) - Defines the methods required for an implementation of a user JSON Web Token provider.
+- **IUserTokenProvider** (src/Altinn.App.Core/Internal/Auth/IUserTokenProvider.cs) - Defines the methods required for an implementation of a user JSON Web Token provider.
+- **IValidateQueryParamPrefill** (src/Altinn.App.Core/Features/IValidateQueryParamPrefill.cs) - Allows service owners to validate values of prefill from query params
+- **IValidationService** (src/Altinn.App.Core/Internal/Validation/IValidationService.cs) - Core interface for validation of instances. Only a single implementation of this interface should exist in the app.
+- **IValidator** (src/Altinn.App.Core/Features/IValidator.cs) - Main interface for validation of instances
+- **IValidatorFactory** (src/Altinn.App.Core/Internal/Validation/IValidatorFactory.cs) - Interface for a factory that can provide validators for a given task or data element.
+- **IX509CertificateProvider** (src/Altinn.App.Core/Infrastructure/Clients/Maskinporten/IX509CertificateProvider.cs) - Provides a X509 certificate abstracted from the underlying implementation which

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,24 @@
+# Arkitekturoversikt
+
+Dette dokumentet gir et helhetlig bilde av bibliotekene i dette prosjektet og hvordan de henger sammen. Informasjonen er basert på inline-dokumentasjonen i kildekoden kombinert med en overordnet forståelse av prosjektet.
+
+## Komponenter
+
+- **Altinn.App.Core** – Kjernefunksjonalitet for Altinn-applikasjoner. Her finnes modeller, tjenester og grensesnitt for prosesshåndtering, datalagring, autentisering og integrasjon mot eksterne systemer.
+- **Altinn.App.Api** – Web API som eksponerer funksjoner fra `Altinn.App.Core` som HTTP-endepunkter. Inneholder controllere for autentisering, applikasjonsmetadata, handlinger og mer.
+- **Altinn.App.Analyzers** – Roslyn-analyzere som hjelper utviklere å skrive riktig app-kode ved å oppdage vanlige feil under kompilering.
+
+I tillegg finnes `Altinn.App.Internal.Analyzers` som inkluderer ekstra analyser beregnet for intern bruk.
+
+## Flyt mellom lag
+
+Applikasjonens frontend kommuniserer med API-laget i `Altinn.App.Api`. Controllerne her bruker tjenester fra `Altinn.App.Core` til å utføre nødvendig logikk. `Altinn.App.Core` tilbyr igjen klienter og abstraksjoner for å samhandle med Altinn Platform og andre eksterne systemer.
+
+## Utvidbarhet
+
+Mye av funksjonaliteten beskrives gjennom grensesnitt merket med attributtet `ImplementableByApps`. Disse kan app-utviklere implementere i sin egen kode for å koble inn egendefinert logikk. Eksempler er `IUserAction` for å definere brukerhandlinger eller `IInstantiationProcessor` for å tilpasse instansiering av data.
+
+## Testing
+
+Prosjektet inneholder en egen `test`-mappe med enhetstester. Ved å kjøre `dotnet test` kan man verifisere funksjonaliteten i både kjerne og API-lag. (I Codex-miljøet er ikke .NET tilgjengelig, så testene kan ikke kjøres her.)
+


### PR DESCRIPTION
## Summary
- add a new architecture overview document describing the Altinn App libraries
- link to the overview from the docs index
- regenerate the interface list from XML comments for a more complete overview

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1035541c8327905de4374b51067d